### PR TITLE
Fix the email case documents functionality

### DIFF
--- a/app/src/cases/caseService.js
+++ b/app/src/cases/caseService.js
@@ -123,7 +123,6 @@
         }
 
         function sendEmail(caseId, message) {
-            console.log(message);
             return $http.post('/alfresco/service/api/openesdh/case/' + caseId + '/email', message).then(function (response) {
                 return response.data;
             });

--- a/app/src/documents/DocumentController.js
+++ b/app/src/documents/DocumentController.js
@@ -26,7 +26,7 @@
         var vm = this;
         vm.caseId = caseId;
         vm.pageSize = 10;
-        vm.isAdmin = sessionService.isAdmin;
+        vm.isAdmin = sessionService.isAdmin();
         
         vm.loadDocuments = loadDocuments;
         vm.uploadDocument = uploadDocument;

--- a/app/src/documents/DocumentController.js
+++ b/app/src/documents/DocumentController.js
@@ -140,10 +140,11 @@
             }
             function emailDocuments() {
                 // Send the email
-                var toList = '';
+                var toList = [];
                 for (var person in vm.to) {
-                  toList += vm.to[person].contactId + '; ';
-                };
+                  // Backend still expects objects with nodeRef property
+                  toList.push({nodeRef: vm.to[person].nodeRef});
+                }
                 caseService.sendEmail(caseId, {
                     'to': toList,
                     'subject': vm.subject,


### PR DESCRIPTION
It has become non-functional. The 'to'  parameter accepts an array of objects with nodeRef properties, not a string.
